### PR TITLE
Mac news list combine user and friends

### DIFF
--- a/src/components/events/EventsProvider.js
+++ b/src/components/events/EventsProvider.js
@@ -41,7 +41,7 @@ export const EventsProvider = (props) => {
         .then(getEvents)
 }
 
-const deletEevents = eventsId => {
+const deleteEevents = eventsId => {
     return fetch(`http://localhost:8088/events/${eventsId}`, {
         method: "DELETE"
     })
@@ -59,7 +59,7 @@ const deletEevents = eventsId => {
     
     return (
       <EventsContext.Provider value={{
-        events, addEvents, editEvents, deletEevents
+        events, addEvents, editEvents, deleteEevents
       }}>
             {props.children}
         </EventsContext.Provider>

--- a/src/components/news/News.js
+++ b/src/components/news/News.js
@@ -7,6 +7,8 @@ export default ({ news }) => (
         <div className="news__title">{news.title}</div>
         <div className="news__synopsis">{news.synopsis}</div>
         <div className="news__url">{news.url}</div>
+        <div className="news__url">posted by {news.user.name}</div>
+
 
 
     </section>

--- a/src/components/news/NewsList.js
+++ b/src/components/news/NewsList.js
@@ -2,30 +2,30 @@ import React, { useContext } from "react"
 import { NewsContext } from "./NewsProvider"
 import { FriendsContext } from "../user/FriendsProvider"
 import News from "./News"
-// import "./Animals.css"
+
+// -daniel and mac
 
 
 export default (props) => {
   const { news } = useContext(NewsContext)
   const { friends } = useContext(FriendsContext)
   const currentUser = parseInt(localStorage.getItem("currentUserId"), 10)
-  const currentUserFriends = friends.filter(friend => friend.userId === currentUser)
-  const friendsArray = []
-  
+  let friendsNewsArray = []
 
+    friends.map(friend => {
+        if (friend.userId === currentUser) {
+            news.filter(
+                n => {
+                    if (n.userId === friend.friendId) {
+                        friendsNewsArray.push(n)
+                    }
+                  })
+                }
+              })
 
-
-  const currentUserFriendsNews = 
-    currentUserFriends.map(friend => {
-      const currentFriendsNews = news.filter(n => n.userId === friend.id)
-      return currentFriendsNews
-      friendsArray.push(currentFriendsNews)
-
-
-    })
     const currentUserNews = news.filter(news => news.userId === currentUser)
-    const newsArray = currentUserFriendsNews.concat(currentUserNews)
-    console.log(newsArray)
+    const combinedNewsArray = currentUserNews.concat(friendsNewsArray)
+    
 
 
 
@@ -37,33 +37,14 @@ export default (props) => {
         Add News
           </button>
       <article className="newsList">
-
-
-
         {
-          currentUserFriendsNews.map(news => {
+          combinedNewsArray.map(news => {
             return <News key={news.id} news={news} />
-
-
+            
           })
 
         }
       </article>
-
-
-      {/* <article className="newsList">
-
-
-
-        {
-          currentUserNews.map(news => {
-            return <News key={news.id} news={news} />
-
-
-          })
-
-        }
-      </article> */}
     </div>
   )
 }

--- a/src/components/news/NewsProvider.js
+++ b/src/components/news/NewsProvider.js
@@ -13,7 +13,7 @@ export const NewsProvider = (props) => {
     const [news, setNews] = useState([])
 
     const getNews = () => {
-        return fetch("http://localhost:8088/news")
+        return fetch("http://localhost:8088/news?_expand=user")
             .then(res => res.json())
             .then(setNews)
     }

--- a/src/components/news/NewsProvider.js
+++ b/src/components/news/NewsProvider.js
@@ -18,7 +18,7 @@ export const NewsProvider = (props) => {
             .then(setNews)
     }
 
-    const addNews = News => {
+    const addNews = news => {
         return fetch("http://localhost:8088/news", {
             method: "POST",
             headers: {


### PR DESCRIPTION
The NewsList.js component now combines the current users News objects and their friends news objects into one combined array. 

it then maps over that array and Invokes the News.js function on each news object and renders them on the DOM. 

To test make sure that the user has at least one friend that has posted an article and that the user has posted at least one article 

example:

```json

"users": [
    {
      "email": "1@1",
      "password": "1",
      "name": "hellow hello",
      "id": 17
    }
],
"news": [
    {
      "id": 7,
      "title": "News",
      "synopsis": "friday",
      "url": "www.news.com",
      "userId": 17
    },
    {
      "title": "How to create your pony",
      "synopsis": "a detailed tutorial on how to create your very own MLP icon",
      "url": "www.mlpFANbase.com",
      "userId": 17,
      "date": 1579638200996,
      "id": 9
    },
    {
      "title": "What it Means to Be a Brony",
      "synopsis": "everything you need to know about being a brony",
      "url": "www.mylittlepony.com",
      "userId": 12,
      "date": 1579638622694,
      "id": 10
    },
],
"friends": [
    {
      "friendId": 12,
      "userId": 17,
      "id": 1
    }
]
```
